### PR TITLE
replace massive log files with a database and garbage collect users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ run.sh
 log.txt
 *.pyc
 config.ini
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ log.txt
 *.pyc
 config.ini
 *.log
+*.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ Jinja2==2.11.1
 MarkupSafe==1.1.1
 requests==2.23.0
 six==1.14.0
-spotipy==2.10.0
+spotipy==2.13.0
 urllib3==1.25.8
 Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@ certifi==2019.11.28
 chardet==3.0.4
 click==7.1.1
 Flask==1.1.2
+gevent==20.4.0
+greenlet==0.4.15
+gunicorn==20.0.4
 idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ Jinja2==2.11.1
 MarkupSafe==1.1.1
 requests==2.23.0
 six==1.14.0
-spotipy==2.13.0
+spotipy==2.16.1
 urllib3==1.25.8
 Werkzeug==1.0.1

--- a/src/app.py
+++ b/src/app.py
@@ -43,7 +43,7 @@ class App(object):
                 message = timestamp + ": " + message
                 # print(message)
                 database.increment_field(id, "error_count")
-                database.update_user(id, "last_error", str(e))
+                database.update_user(id, "last_error", message)
                 # with open(constant.SRC_PATH + '/../error.log', 'a') as f:
                 #     f.write(message)
                 #     f.write(traceback.format_exc())

--- a/src/app.py
+++ b/src/app.py
@@ -36,6 +36,9 @@ class App(object):
             try:
                 token = oauth.get_cached_token()['access_token']
                 playlist.update_playlist(spotipy.Spotify(auth=token))
+
+                # reset the users error count if an update was successful
+                database.update_user(id, "error_count", 0)
             except Exception as e:
                 timestamp = dt.now(tz=tz.utc).strftime('%Y-%m-%d %H:%M:%S')
                 # message = "Unable to update playlist for: " + id + "\n"

--- a/src/app.py
+++ b/src/app.py
@@ -58,7 +58,6 @@ class App(object):
                         os.remove(cache_path)
                     except OSError:
                         pass
-                    database.remove_user(id)
 
 
     # Runs every n seconds on a separate thread

--- a/src/app.py
+++ b/src/app.py
@@ -47,7 +47,6 @@ class App(object):
                 # with open(constant.SRC_PATH + '/../error.log', 'a') as f:
                 #     f.write(message)
                 #     f.write(traceback.format_exc())
-
     # Runs every n seconds on a separate thread
     # update_frequency: how frequently to update in seconds
     def run(self, update_frequency):

--- a/src/app.py
+++ b/src/app.py
@@ -39,8 +39,8 @@ class App(object):
             except Exception as e:
                 timestamp = dt.now(tz=tz.utc).strftime('%Y-%m-%d %H:%M:%S')
                 # message = "Unable to update playlist for: " + id + "\n"
-                # message += str(e)
-                # message = timestamp + ": " + message
+                message = str(e)
+                message = timestamp + ": " + message
                 # print(message)
                 database.increment_field(id, "error_count")
                 database.update_user(id, "last_error", str(e))

--- a/src/app.py
+++ b/src/app.py
@@ -55,7 +55,7 @@ class App(object):
                 # token, they probably revoked our access
                 if database.get_field(id, "error_count") > constant.ERROR_THRESHOLD:
                     try:
-                        os.remove(filename)
+                        os.remove(cache_path)
                     except OSError:
                         pass
                     database.remove_user(id)

--- a/src/app.py
+++ b/src/app.py
@@ -38,12 +38,12 @@ class App(object):
                 playlist.update_playlist(spotipy.Spotify(auth=token))
             except Exception as e:
                 timestamp = dt.now(tz=tz.utc).strftime('%Y-%m-%d %H:%M:%S')
-                message = "Unable to update playlist for: " + id + "\n"
+                # message = "Unable to update playlist for: " + id + "\n"
                 # message += str(e)
                 # message = timestamp + ": " + message
                 # print(message)
                 database.increment_field(id, "error_count")
-                database.update_user(id, "last_error", message)
+                database.update_user(id, "last_error", str(e))
                 # with open(constant.SRC_PATH + '/../error.log', 'a') as f:
                 #     f.write(message)
                 #     f.write(traceback.format_exc())

--- a/src/app.py
+++ b/src/app.py
@@ -47,6 +47,17 @@ class App(object):
                 # with open(constant.SRC_PATH + '/../error.log', 'a') as f:
                 #     f.write(message)
                 #     f.write(traceback.format_exc())
+
+                # if a user passes a certain number of errors, delete their 
+                # token, they probably revoked our access
+                if database.get_field(id, "error_count") > constant.ERROR_THRESHOLD:
+                    try:
+                        os.remove(filename)
+                    except OSError:
+                        pass
+                    database.remove_user(id)
+
+
     # Runs every n seconds on a separate thread
     # update_frequency: how frequently to update in seconds
     def run(self, update_frequency):

--- a/src/constant.py
+++ b/src/constant.py
@@ -9,5 +9,5 @@ SRC_PATH = os.path.dirname(os.path.realpath(__file__))
 CACHE_PATH = SRC_PATH + "/../cache"
 SCOPE = "user-library-read playlist-read-private playlist-modify-private playlist-modify-public"
 UPDATE_FREQUENCY = 600 # in seconds
-DATABASE_NAME = SRC_PATH + "/database.db"
+DATABASE_NAME = SRC_PATH + "/../database.db"
 ERROR_THRESHOLD = 30

--- a/src/constant.py
+++ b/src/constant.py
@@ -9,3 +9,4 @@ SRC_PATH = os.path.dirname(os.path.realpath(__file__))
 CACHE_PATH = SRC_PATH + "/../cache"
 SCOPE = "user-library-read playlist-read-private playlist-modify-private playlist-modify-public"
 UPDATE_FREQUENCY = 600 # in seconds
+DATABASE_NAME = "database.db"

--- a/src/constant.py
+++ b/src/constant.py
@@ -10,3 +10,4 @@ CACHE_PATH = SRC_PATH + "/../cache"
 SCOPE = "user-library-read playlist-read-private playlist-modify-private playlist-modify-public"
 UPDATE_FREQUENCY = 600 # in seconds
 DATABASE_NAME = "database.db"
+ERROR_THRESHOLD = 30

--- a/src/constant.py
+++ b/src/constant.py
@@ -9,5 +9,5 @@ SRC_PATH = os.path.dirname(os.path.realpath(__file__))
 CACHE_PATH = SRC_PATH + "/../cache"
 SCOPE = "user-library-read playlist-read-private playlist-modify-private playlist-modify-public"
 UPDATE_FREQUENCY = 600 # in seconds
-DATABASE_NAME = "database.db"
+DATABASE_NAME = SRC_PATH + "/database.db"
 ERROR_THRESHOLD = 30

--- a/src/database.py
+++ b/src/database.py
@@ -16,7 +16,12 @@ def get_user(id):
 def update_user(id, field, value):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
-    cursor.execute(f'UPDATE Users SET {field}="{value}" WHERE id="{id}"')
+    
+    # really scuffed, dynamic type abuse
+    if type(value) == str:
+        cursor.execute(f'UPDATE Users SET {field}="{value}" WHERE id="{id}"')
+    else:
+        cursor.execute(f'UPDATE Users SET {field}={value} WHERE id="{id}"')
     conn.commit()
     conn.close()
 

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,54 @@
+import sqlite3
+import os
+
+from constant import CACHE_PATH, DATABASE_NAME
+# utility functions for manipulating the database
+# aka abstracting away all the sql
+
+def get_user(id):
+    conn = sqlite3.connect(DATABASE_NAME)
+    cursor = conn.cursor()
+    cursor.execute(f'SELECT * FROM Users WHERE id="{id}"')
+    conn.commit()
+    conn.close()
+    return cursor.fetchone()
+
+def update_user(id, field, value):
+    conn = sqlite3.connect(DATABASE_NAME)
+    cursor = conn.cursor()
+    cursor.execute(f'UPDATE Users SET {field}="{value}" WHERE id="{id}"')
+    conn.commit()
+    conn.close()
+
+def increment_field(id, field):
+    conn = sqlite3.connect(DATABASE_NAME)
+    cursor = conn.cursor()
+    cursor.execute(f'SELECT {field} FROM Users WHERE id = "{id}"')
+    entry = cursor.fetchone()[0]
+    update_user(id, field, entry + 1)
+    conn.close()
+
+def add_user(id):
+    conn = sqlite3.connect(DATABASE_NAME)
+    cursor = conn.cursor()
+    conn.execute(f'INSERT INTO Users(id) VALUES("{id}")')
+    conn.commit()
+    conn.close()
+
+def init_database():
+    conn = sqlite3.connect(DATABASE_NAME)
+    cursor = conn.cursor()
+    cursor.execute(''' SELECT count(name) FROM sqlite_master WHERE type='table' AND name='Users' ''')
+    if cursor.fetchone()[0] == 0:
+        conn.execute(''' CREATE TABLE Users(
+            id TEXT,
+            update_count INTEGER DEFAULT 0,
+            error_count INTEGER DEFAULT 0,
+            last_error TEXT DEFAULT "",
+            last_playlist TEXT DEFAULT "",
+            last_update TEXT DEFAULT ""
+        ) ''')
+        for filename in os.listdir(CACHE_PATH):
+            id = filename[len(".cache-"):]
+            add_user(id)
+    conn.close()

--- a/src/database.py
+++ b/src/database.py
@@ -20,18 +20,30 @@ def update_user(id, field, value):
     conn.commit()
     conn.close()
 
-def increment_field(id, field):
+def get_field(id, field):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
     cursor.execute(f'SELECT {field} FROM Users WHERE id = "{id}"')
     entry = cursor.fetchone()[0]
     update_user(id, field, entry + 1)
     conn.close()
+    return entry
+
+def increment_field(id, field):
+    entry = get_field(id, field)
+    update_user(id, field, entry + 1)
 
 def add_user(id):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
     conn.execute(f'INSERT INTO Users(id) VALUES("{id}")')
+    conn.commit()
+    conn.close()
+
+def remove_user(id):
+    conn = sqlite3.connect(DATABASE_NAME)
+    cursor = conn.cursor()
+    conn.execute(f'DELETE FROM Users WHERE id = "{id}"')
     conn.commit()
     conn.close()
 

--- a/src/database.py
+++ b/src/database.py
@@ -48,6 +48,10 @@ def increment_field(id, field):
 def add_user(id):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
+    # reset user if they reregister
+    if get_user(id) != None:
+        remove_user(id)
+
     sql = f'INSERT INTO Users(id) VALUES("{id}")'
     conn.execute(sql)
     conn.commit()

--- a/src/database.py
+++ b/src/database.py
@@ -50,11 +50,11 @@ def add_user(id):
     cursor = conn.cursor()
     # reset user if they reregister
     if get_user(id) != None:
-        remove_user(id)
-
-    sql = f'INSERT INTO Users(id) VALUES("{id}")'
-    conn.execute(sql)
-    conn.commit()
+        update_user(id, "error_count", 0)
+    else:
+        sql = f'INSERT INTO Users(id) VALUES(?)'
+        conn.execute(sql, (id))
+        conn.commit()
     conn.close()
 
 def remove_user(id):

--- a/src/database.py
+++ b/src/database.py
@@ -8,10 +8,15 @@ from constant import CACHE_PATH, DATABASE_NAME
 def get_user(id):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
-    cursor.execute(f'SELECT * FROM Users WHERE id="{id}"')
+    sql = f'SELECT * FROM Users WHERE id="{id}"'
+    cursor.execute(sql)
+    row = cursor.fetchone()
     conn.commit()
     conn.close()
-    return cursor.fetchone()
+    if row:
+        return row[0]
+    else:
+        return None
 
 def update_user(id, field, value):
     conn = sqlite3.connect(DATABASE_NAME)
@@ -19,16 +24,18 @@ def update_user(id, field, value):
     
     # really scuffed, dynamic type abuse
     if type(value) == str:
-        cursor.execute(f'UPDATE Users SET {field}="{value}" WHERE id="{id}"')
+        sql = f'UPDATE Users SET {field}="{value}" WHERE id="{id}"'
     else:
-        cursor.execute(f'UPDATE Users SET {field}={value} WHERE id="{id}"')
+        sql = f'UPDATE Users SET {field}={value} WHERE id="{id}"'
+    cursor.execute(sql)
     conn.commit()
     conn.close()
 
 def get_field(id, field):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
-    cursor.execute(f'SELECT {field} FROM Users WHERE id = "{id}"')
+    sql = f'SELECT {field} FROM Users WHERE id = "{id}"'
+    cursor.execute(sql)
     entry = cursor.fetchone()[0]
     update_user(id, field, entry + 1)
     conn.close()
@@ -41,14 +48,16 @@ def increment_field(id, field):
 def add_user(id):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
-    conn.execute(f'INSERT INTO Users(id) VALUES("{id}")')
+    sql = f'INSERT INTO Users(id) VALUES("{id}")'
+    conn.execute(sql)
     conn.commit()
     conn.close()
 
 def remove_user(id):
     conn = sqlite3.connect(DATABASE_NAME)
     cursor = conn.cursor()
-    conn.execute(f'DELETE FROM Users WHERE id = "{id}"')
+    sql = f'DELETE FROM Users WHERE id = "{id}"'
+    conn.execute(sql)
     conn.commit()
     conn.close()
 

--- a/src/playlist.py
+++ b/src/playlist.py
@@ -1,4 +1,5 @@
 import constant
+import database
 from collections import deque
 from datetime import datetime as dt
 from datetime import timezone as tz
@@ -80,7 +81,11 @@ def update_playlist(client):
         pass
     else:
         timestamp = dt.now(tz=tz.utc).strftime('%Y-%m-%d %H:%M:%S')
-        print(timestamp + ": Adding " + str(len(songs_to_be_added)) + " songs for", client.me()['id'])
+        # print(timestamp + ": Adding " + str(len(songs_to_be_added)) + " songs for", client.me()['id'])
+        database.update_user(client.me()['id'], "last_playlist", target_playlist)
+        database.update_user(client.me()['id'], "last_update", timestamp)
+        database.increment_field(client.me()['id'], "update_count")
+
         # we can only add 100 songs at a time, place all the songs in a queue
         # and dequeue into a chunk 100 songs at a time
         chunk = []

--- a/src/playlist.py
+++ b/src/playlist.py
@@ -76,13 +76,14 @@ def update_playlist(client):
     # in utc
     last_updated = get_newest_date_in_playlist(target_playlist, client)
     songs_to_be_added = get_unadded_songs(last_updated, client)
+
+    database.update_user(client.me()['id'], "last_playlist", target_playlist)
     if len(songs_to_be_added) < 1:
         # print("No songs to be added for", client.me()['id'])
         pass
     else:
         timestamp = dt.now(tz=tz.utc).strftime('%Y-%m-%d %H:%M:%S')
         # print(timestamp + ": Adding " + str(len(songs_to_be_added)) + " songs for", client.me()['id'])
-        database.update_user(client.me()['id'], "last_playlist", target_playlist)
         database.update_user(client.me()['id'], "last_update", timestamp)
         database.increment_field(client.me()['id'], "update_count")
 

--- a/src/web_auth.py
+++ b/src/web_auth.py
@@ -1,5 +1,6 @@
 import config
 import constant
+import database
 import spotipy
 import os
 from spotipy.oauth2 import SpotifyOAuth, SpotifyOauthError
@@ -51,8 +52,13 @@ def auth_page():
         # create a new playlist for new users
         if not os.path.exists(client_cache):
             update_playlist(client)
+        
         # rename cache file to user
         os.rename(oauth.cache_path, client_cache)
+        
+        # add user to database
+        database.add_user(client.me()['id'])
+
         return render_template("auth_success.html")
 
 @auth_server.route('/logout')


### PR DESCRIPTION
Last error + timestamp and last update timestamp now get stored in an sqlite database instead of a massive log file
Users that error more than 30 times without a successful update are considered dead and get removed
I think temp files are created by people clicking the button and then closing the tab without actually giving permissions, those get properly removed now